### PR TITLE
Delete incorrect CSS rules for no-details mode

### DIFF
--- a/less/forum/extension.less
+++ b/less/forum/extension.less
@@ -9,14 +9,6 @@ details {
 
 .no-details {
   details {
-    :not(summary) {
-      display: none;
-    }
-
-    &.open * {
-      display: block;
-    }
-
     summary:before {
       content: '► ';
     }


### PR DESCRIPTION
If you browser dont support natively details tag, this rules crashes content. And more, this styles dont needed for correct work of this plugin, because content block [already have](http://linkme.ufanet.ru/images/7f0200907dd37ca0cbe3f56aea0d4777.png) `style='display:none'` rule.

![](http://linkme.ufanet.ru/images/196779d26a6f23d27c7d26b18c6e5c59.png)

After deleting this rules everything works fine.
